### PR TITLE
Removing elm-test dependency from root elm-package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ install:
 before_script:
   - cd tests
   - elm-make --yes --output ../raw-test.js Tests.elm
+  - cd ..
 script: 
   - elm-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: haskell
 install:
   - npm install -g elm
+  - npm install -g elm-test
   - elm-package install -y
 before_script:
   - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ install:
   - npm install -g elm
   - elm-package install -y
 before_script:
-  - elm-make --yes --output raw-test.js tests/Tests.elm
-script: elm test
+  - cd tests
+  - elm-make --yes --output ../raw-test.js Tests.elm
+script: 
+  - elm-test

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,6 @@
         "String.Interpolate"
     ],
     "dependencies": {
-        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
**The Problem**
My team is trying to include packages into our tests elm-package.json that require an elm-test version greater than 4.0.0. (An example: [elm-html-test](https://github.com/eeue56/elm-html-test/blob/5.1.1/elm-package.json)) Since this package's elm-test dependency has a version range below 4.0.0 we are unable to include the other packages.

**The Proposed Solution**
My proposal is to remove the elm-test dependency from the root elm-package.json. The core elm module does not directly depend on elm-test and successfully compiles without it. The tests folder elm-package.json still declares elm-test as its dependency. 

Testing steps:

- Removed elm-stuff from root directory, recompiled package, and verified that both elm-stuff was recreated and the package successfully compiled.

- Removed elm-stuff from test directory, ran elm-test to recompile and run tests, and verified that both elm-stuff was recreated and that the unit test passed.