### PR TITLE
Remove top-level package dependency on elm-test

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,6 @@
         "String.Interpolate"
     ],
     "dependencies": {
-        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -13,7 +13,7 @@
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
Hey @lukewestby! I noticed that I could not test my modules that depend on this package. When I add your package as a dependency in my `tests/elm-package.json`, I get the error `Error: I cannot find a set of packages that works with your constraints` because it depends on an old version of elm-test.

There's no need for this package-level dependency so I think just removing it should fix the problem.

Cheers,

Dillon