### PR TITLE
Qualify `Regex.never` so it doesn't conflict with `Basics.never`

### DIFF
--- a/src/String/Interpolate.elm
+++ b/src/String/Interpolate.elm
@@ -29,7 +29,7 @@ interpolate string args =
 
 interpolationRegex : Regex
 interpolationRegex =
-    fromString "\\{\\d+\\}" |> withDefault never
+    fromString "\\{\\d+\\}" |> withDefault Regex.never
 
 
 applyInterpolation : Array String -> Match -> String


### PR DESCRIPTION
Hey dude!

This is because of a subtle bugish thing in 0.19 that will likely be fixed in upcoming versions, where you can't shadow imports from Basics.